### PR TITLE
[2단계 - Virtual DOM 만들기] 지그(송지은) 미션 제출합니다.

### DIFF
--- a/src/components/Counter.js
+++ b/src/components/Counter.js
@@ -1,14 +1,26 @@
 import Zig from '../lib/zig-react';
 
 const Counter = () => {
-  const [getCount, setCount] = Zig.useState(0);
+  const [initialCount, setCount] = Zig.useState(0);
+
+  const count = new Proxy(initialCount, {
+    get(target, prop) {
+      try {
+        let value = target[prop];
+
+        return typeof target.value === 'function' ? value.call(target) : target.value;
+      } catch (error) {
+        console.error(`Proxy get Error: ${error}`);
+      }
+    },
+  });
 
   const decrease = () => {
-    setCount(getCount() - 1);
+    setCount(count.value - 1);
   };
 
   const increase = () => {
-    setCount(getCount() + 1);
+    setCount(count.value + 1);
   };
 
   const reset = () => {
@@ -19,7 +31,7 @@ const Counter = () => {
     Zig.createElement(
       'div',
       { className: 'container' },
-      Zig.createElement('span', { className: 'count' }, getCount()),
+      Zig.createElement('span', { className: 'count' }, count.value),
       Zig.createElement(
         'div',
         { className: 'btn-group' },

--- a/src/lib/zig-react.js
+++ b/src/lib/zig-react.js
@@ -30,6 +30,10 @@ const Zig = (function () {
 
     const getState = () => hooks[_idx] || initialValue;
 
+    const state = {
+      value: getState,
+    };
+
     const setState = (newValue) => {
       hooks[_idx] = newValue;
 
@@ -38,7 +42,7 @@ const Zig = (function () {
 
     idx++;
 
-    return [getState, setState];
+    return [state, setState];
   };
 
   return { createElement, useState };


### PR DESCRIPTION
1단계에서 이미 `useState`를 구현했어서, 2단계 미션에서는 기존의 `useState`를 Proxy로 받아오도록 수정해보았습니다.

`Counter` 컴포넌트에서 더 이상 `getState()`로 직접 호출할 필요는 없지만, 
`state`에 Proxy를 적용해주기 위해 `state`를 객체로 만들다보니 `state.value`와 같이 접근해야 하는 문제(?)는 있습니다

그래도 새로운 개념을 적용시켜본 것에 의의를... ㅎㅅㅎ

앱은 지난번과 같이 [여기서 확인 가능](https://zig-counter.netlify.app/)합니다! 